### PR TITLE
fix(ci): resolve test failures in release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,7 @@ test-all: ## Run all tests
 	@echo "🧪 Testing JavaScript SDK..."
 	cd scoutquest-js && pnpm test
 	@echo "🧪 Running integration tests..."
-	cd examples/rust && cargo test
-	cd examples/js && pnpm test
+	cd examples/rust && cargo test --bins --tests --benches
 
 docs-build: ## Build documentation website
 	@echo "📚 Building documentation website..."

--- a/examples/rust/notification_example/src/lib.rs
+++ b/examples/rust/notification_example/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Usage
 //!
-//! ```rust
+//! ```rust,no_run
 //! use notification_example::{
 //!     client::NotificationClient,
 //!     types::{CreateNotificationRequest, Channel, Priority},


### PR DESCRIPTION
- Add no_run flag to notification example doctest to prevent network calls
- Remove examples/js tests from Makefile (no test script defined)
- Focus integration tests on bins/tests/benches only
- Ensure CI passes without requiring running services