### PR TITLE
fix: resolve Docker build issues in semantic-release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Universal Service Discovery for microservices architectures**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Latest Release](https://img.shields.io/github/v/release/RomainDECOSTER/scoutquest?label=version)](https://github.com/RomainDECOSTER/scoutquest/releases/latest)
+[![Latest Tag](https://img.shields.io/github/v/tag/RomainDECOSTER/scoutquest?label=version)](https://github.com/RomainDECOSTER/scoutquest/tags)
 [![Build Status](https://github.com/RomainDECOSTER/scoutquest/workflows/CI/badge.svg)](https://github.com/RomainDECOSTER/scoutquest/actions)
 [![Release](https://github.com/RomainDECOSTER/scoutquest/workflows/Release/badge.svg)](https://github.com/RomainDECOSTER/scoutquest/actions)
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://romaindecoster.github.io/scoutquest/)

--- a/scoutquest-server/.dockerignore
+++ b/scoutquest-server/.dockerignore
@@ -1,6 +1,5 @@
 # Build artifacts
 target/
-Cargo.lock
 
 # Git and CI
 .git

--- a/scoutquest-server/Dockerfile
+++ b/scoutquest-server/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:1.89 AS builder
 WORKDIR /app
 
 # Copy Cargo files first for better layer caching
-COPY Cargo.toml ./
+COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY config ./config
 


### PR DESCRIPTION
## 🐛 Bug Fix: Docker Build Issues in Semantic-Release

This PR fixes the Docker build failures that were causing semantic-release to fail with exit code 2.

### 🔧 Changes Made

1. **Fixed `.dockerignore`**: Removed `Cargo.lock` from exclusions to ensure reproducible builds
2. **Updated Dockerfile**: Added explicit `Cargo.lock` copy for better dependency management
3. **README Badge**: Updated to use tag-based version badge for immediate functionality

### 🧪 Testing

✅ Docker build tested successfully locally:
```bash
cd scoutquest-server && docker build -t scoutquest/server:test .
```

### 🎯 Impact

- Resolves `Command failed with exit code 2: make release-publish VERSION=1.2.0`
- Enables successful Docker image builds during release process
- Improves build reproducibility with proper `Cargo.lock` handling

### 📋 Checklist

- [x] Docker build tested and working
- [x] README badge updated and functional
- [x] Cargo.lock properly included in Docker context
- [x] Pre-commit hooks passed