### PR TITLE
fix(docker): resolve config file path in multi-stage build

### DIFF
--- a/scoutquest-server/Dockerfile
+++ b/scoutquest-server/Dockerfile
@@ -7,7 +7,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY config ./config
 
-# Build the server
+# Build with optimizations for CI environment
 RUN cargo build --release
 
 FROM debian:bookworm-slim
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 COPY --from=builder /app/target/release/scoutquest-server .
-COPY --from=builder /app/config/default.toml ./config.toml
+COPY config/default.toml ./config.toml
 
 
 ENV RUST_LOG=info


### PR DESCRIPTION
- Fix COPY command to use build context path instead of builder stage path
- Change from 'COPY --from=builder /app/config/default.toml' to 'COPY config/default.toml'
- Resolves GitHub Actions build error: 'config/default.toml: not found'
- Maintains local build compatibility while fixing CI/CD pipeline

The issue occurred because in GitHub Actions, the Docker build context is scoutquest-server/ directory, so config files must be copied from the build context rather than the builder stage intermediate filesystem.

Fixes: 'failed to calculate checksum' error in semantic-release workflow