### PR TITLE
fix(docker): remove config file copy - use application defaults

### DIFF
--- a/scoutquest-server/Dockerfile
+++ b/scoutquest-server/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 COPY --from=builder /app/target/release/scoutquest-server .
-COPY config/default.toml ./config.toml
 
 
 ENV RUST_LOG=info


### PR DESCRIPTION
- Remove 'COPY config/default.toml ./config.toml' from Dockerfile
- Root cause: config/*.toml files are gitignored, so file not available in CI
- Application handles missing config gracefully with default values
- Fixes GitHub Actions build error: 'config/default.toml: not found'

The ScoutQuest server is designed to work without external config files:
- Uses AppConfig::default() when config.toml is missing
- Can be configured via SCOUTQUEST_* environment variables
- Reduces Docker image complexity and CI/CD dependencies

Resolves: 'failed to calculate checksum' error in semantic-release workflow